### PR TITLE
Add custom category for the test connectors

### DIFF
--- a/gitbuilding/arduino_cncshield.md
+++ b/gitbuilding/arduino_cncshield.md
@@ -128,7 +128,7 @@ You can set the current limit as follow:
 
 * Make sure the Arduino board is powered (plugged to turned-on computer with USB cable);  
 * Turn your [multimeter](Parts.yaml#Multimeter){qty:1, Cat:tool} on, and set it to voltage measurement;  
-* Connect it to a ground GND pin on the CNC shield. To do so, connect a [female to male jumper wire](Parts.yaml#JumpersWires_FemaleMale){qty:1} to the GND pin, then connect it to the black probe of the multimeter with a [crocodile clip](Parts.yaml#CrocodileClip){qty:1, Cat:tool};  
+* Connect it to a ground GND pin on the CNC shield. To do so, connect a [female to male jumper wire](Parts.yaml#JumpersWires_FemaleMale){qty:1} to the GND pin, then connect it to the black probe of the multimeter with a [crocodile clip](Parts.yaml#CrocodileClip){qty:1, Cat:testconnector};  
 * Clip another [crocodile clip]{qty:1} to a tiny screwdriver with conductive tip, and to the red probe of the multimeter;  
 * Turn the potentiometer on the A4988 chip until you read VREF.
 

--- a/gitbuilding/buildconf.yaml
+++ b/gitbuilding/buildconf.yaml
@@ -10,10 +10,10 @@ Email: engineering@centuri-livingsystems.org
 
 
 #Uncomment below to add custom categories
-#CustomCategories:
-#    printedtool:
-#        Reuse: False
-#        DisplayName: Printed tools
+CustomCategories:
+    testconnector:
+        Reuse: False
+        DisplayName: Test Connectors
 
 #Uncomment below to set a custom default category
 #DefaultCategory: printedtool


### PR DESCRIPTION
Hi Mathias,

Sorry for stalking you over to here! I was interested in seeing someone else using GitBuilding. I see that you probably don't want the croc clips to be listed as parts, but then want them to enumerate whereas tools do not.

You could just set the qty to 2 for the croc clips as you know that is how many you will need. As an alternative the pull request creates a custom category where "Reuse" is set to false so that the clips count like parts.

I'll work on the documentation of GitBuilding to try to make this clearer. Ideally it would be more intuitive, I will have a think.